### PR TITLE
updated exemptionAsserted from integer to dateTime

### DIFF
--- a/terms/dri_vocabulary.owl
+++ b/terms/dri_vocabulary.owl
@@ -669,7 +669,7 @@ dri:exemptionAsserted
   a owl:DatatypeProperty ;
   rdfs:domain dri:Closure ;
   rdfs:label "FOI exemption asserted" ;
-  rdfs:range xsd:integer ;
+  rdfs:range xsd:dateTime ;
 .
 dri:exemptionCode
   a owl:ObjectProperty ;


### PR DESCRIPTION
Simple change, tested with my local TBC by editing the vocab directly, and it correctly changed the exemptionAsserted from integer to dateTime.